### PR TITLE
Fix offset when assembling V_response

### DIFF
--- a/FreqResponseModel.cs
+++ b/FreqResponseModel.cs
@@ -116,6 +116,7 @@ namespace TfmrLib
             // Enumerate through raw turn responses (vector of Complex Gain for each turn) at each frequency
             for (int f = 0; f < NumSteps; f++)
             {
+                int offset = 0;
                 // Enumerate through each winding
                 foreach (var wdg in Tfmr.Windings)
                 {
@@ -123,8 +124,9 @@ namespace TfmrLib
                     for (int t = 0; t < (wdg.num_turns - 1); t++)
                     {
                         //Translate to dB
-                        V_response[t][f] = V_turn[f][t];
+                        V_response[offset + t][f] = V_turn[f][offset + t];
                     }
+                    offset += wdg.num_turns;
                 }
             }
 


### PR DESCRIPTION
## Summary
- handle multiple windings correctly when copying responses

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8fcc760832b84133747a3f1dc66